### PR TITLE
Added delete#OrderRoutingGroup service, This servic will delete associated OrderRouting, OrderRoutingRule and dependent refefnces.

### DIFF
--- a/screen/OrderRoutingGroup/OrderRoutingGroupDetail.xml
+++ b/screen/OrderRoutingGroup/OrderRoutingGroupDetail.xml
@@ -4,6 +4,8 @@
 
     <parameter name="routingGroupId" required="true"/>
     <transition name="jobRunList"><default-response url="../JobRuns/JobRunList"/></transition>
+    <transition name="serviceJobDetail">
+        <default-response url="//system/ServiceJob/Jobs/ServiceJobDetail"/></transition>
     <transition name="routingRunList"><default-response url="../OrderRouting/OrderRoutingRunList"/></transition>
     <transition name="orderRoutingDetail"><default-response url="../OrderRouting/OrderRoutingDetail"/></transition>
     <transition name="orderRoutingGroupSchedule">
@@ -26,12 +28,12 @@
         <service-call name="update#co.hotwax.order.routing.OrderRouting"/>
         <default-response url="."/>
     </transition>
+    <transition name="cloneOrderRoutingGroup">
+        <service-call name="co.hotwax.order.routing.OrderRoutingServices.clone#OrderRoutingGroup"/>
+        <default-response url="." parameter-map="[routingGroupId:newRoutingGroupId]"/>
+    </transition>
     <actions>
         <entity-find-one entity-name="co.hotwax.order.routing.OrderRoutingGroup" value-field="orderRoutingGroup"/>
-        <entity-find entity-name="co.hotwax.order.routing.OrderRouting" list="routings">
-            <search-form-inputs default-order-by="^sequenceNum, createdDate"/>
-            <econdition field-name="routingGroupId" from="routingGroupId"/>
-        </entity-find>
         <entity-find-one entity-name="moqui.service.job.ServiceJobRunLock" value-field="runLock">
             <field-map field-name="jobName" from="orderRoutingGroup.jobName"/>
         </entity-find-one>
@@ -56,6 +58,11 @@
             <row-col>
                 <container-box>
                     <box-header title="Order Routing Group"/>
+                    <box-toolbar>
+                        <link url="cloneOrderRoutingGroup" text="Clone" confirmation="Are you sure to clone ${orderRoutingGroup.groupName?:orderRoutingGroup.routingGroupId}?">
+                            <parameter name="routingGroupId" from="orderRoutingGroup.routingGroupId"/>
+                        </link>
+                    </box-toolbar>
                     <box-body>
                         <form-single name="RoutingGroupForm" map="orderRoutingGroup" transition="updateRoutingGroup">
                             <field name="routingGroupId"><default-field><display/> </default-field></field>
@@ -93,7 +100,9 @@
                             <widgets>
                                 <form-single name="RoutingGroupScheduleForm" map="serviceJob" transition="orderRoutingGroupSchedule">
                                     <field name="routingGroupId"><default-field><hidden/></default-field></field>
-                                    <field name="jobName"><default-field><hidden/></default-field></field>
+                                    <field name="jobName">
+                                        <default-field><link url="serviceJobDetail" text="${jobName}" link-type="anchor" url-type="screen"/></default-field>
+                                    </field>
                                     <field name="description"><default-field><text-line/></default-field></field>
                                     <field name="cronExpression"><default-field tooltip="${cronExpressionDesc} ${TimeZone.getDefault().getID()} time"><text-line /></default-field></field>
                                     <field name="nextExecutionTime"><conditional-field condition="nextExecutionTime"><display/></conditional-field></field>
@@ -156,6 +165,10 @@
                     </box-toolbar>
                     <box-body>
                         <form-list name="OrderRouting" list="routings" list-entry="routing" transition="updateOrderRouting">
+                            <entity-find entity-name="co.hotwax.order.routing.OrderRouting" list="routings">
+                                <search-form-inputs default-order-by="^sequenceNum, createdDate"/>
+                                <econdition field-name="routingGroupId" from="routingGroupId"/>
+                            </entity-find>
                             <field name="orderRoutingId">
                                 <default-field><hidden/></default-field>
                             </field>

--- a/screen/OrderRoutingGroup/OrderRoutingGroupList.xml
+++ b/screen/OrderRoutingGroup/OrderRoutingGroupList.xml
@@ -8,6 +8,10 @@
         <service-call name="create#co.hotwax.order.routing.OrderRoutingGroup"/>
         <default-response url="."/>
     </transition>
+    <transition name="deleteOrderRoutingGroup">
+        <service-call name="co.hotwax.order.routing.OrderRoutingServices.delete#OrderRoutingGroup"/>
+        <default-response url="."/>
+    </transition>
 
     <widgets>
         <container-dialog id="AddOrderRoutingGroup" button-text="Add Order Routing Group">
@@ -39,7 +43,7 @@
             </row-actions>
             <field name="groupName">
                 <header-field show-order-by="case-insensitive"><text-find hide-options="true" size="20"/></header-field>
-                <default-field><link text="${groupName?:routingGroupId}" url="orderRoutingGroup" link-type="anchor"/></default-field>
+                <default-field><link text="${groupName?:routingGroupId} [${routingGroupId}]" url="orderRoutingGroup" link-type="anchor"/></default-field>
             </field>
             <field name="productStoreId">
                 <header-field show-order-by="true">
@@ -74,7 +78,10 @@
             </field>
             <field name="findButton">
                 <header-field title="Find"><submit/></header-field>
-                <default-field><display text=" "/></default-field>
+                <default-field title="">
+                    <link url="deleteOrderRoutingGroup" text="X" confirmation="Remove order routing group ${groupName}?"
+                            parameter-map="[routingGroupId:routingGroupId]" condition="ec.user.hasPermission('DELETE_ORDER_ROUTE')"/>
+                </default-field>
             </field>
         </form-list>
     </widgets>

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -620,7 +620,6 @@
             <parameter name="copyOrderRoutingRules" default-value="true" type="Boolean">
                 <description>Parameter to check if the Order routing rule needs to be cloned, works only if copyOrderRoutings set to true.</description>
             </parameter>
-            <parameter name="newGroupName"/>
         </in-parameters>
         <out-parameters>
             <parameter name="newRoutingGroupId" required="true"/>
@@ -656,7 +655,9 @@
         <in-parameters>
             <parameter name="orderRoutingId" required="true"/>
             <parameter name="newRoutingGroupId" required="true"/>
-            <parameter name="copyOrderRoutingRules" default-value="true" type="Boolean"/>
+            <parameter name="copyOrderRoutingRules" default-value="true" type="Boolean">
+                <description>Parameter to check if the Order routing rule needs to be cloned.</description>
+            </parameter>
             <parameter name="newRoutingName"/>
         </in-parameters>
         <out-parameters>
@@ -757,6 +758,32 @@
                 </script>
                 <service-call name="create#co.hotwax.order.routing.OrderRoutingRuleAction" in-map="newOrderRoutingRuleAction"/>
             </iterate>
+        </actions>
+    </service>
+    <!-- Danger Zone-->
+    <!--TODO: Add permission  -->
+    <service verb="delete" noun="OrderRoutingGroup">
+        <in-parameters>
+            <parameter name="routingGroupId" required="true"/>
+        </in-parameters>
+        <actions>
+            <if condition="!ec.user.hasPermission('DELETE_ORDER_ROUTE')">
+                <return error="true" message="User does not have permission to delete order routing group."/>
+            </if>
+            <entity-find-one entity-name="co.hotwax.order.routing.OrderRoutingGroup" value-field="orderRoutingGroup" cache="false"/>
+            <if condition="!orderRoutingGroup">
+                <log level="error" message="No orderRoutingGroup found for id ${routingGroupId}"/>
+                <return error="true" type="warning"/>
+            </if>
+            <entity-find-one entity-name="moqui.service.job.ServiceJob" value-field="serviceJob">
+                <field-map field-name="jobName" from="orderRoutingGroup.jobName"/>
+            </entity-find-one>
+            <if condition="serviceJob">
+                <service-call name="update#moqui.service.job.ServiceJob" in-map="[jobName: orderRoutingGroup.jobName, thruDate: ec.user.nowTimestamp, paused: 'Y']" disable-authz="true"/>
+            </if>
+            <script>
+                orderRoutingGroup.deleteWithCascade(['OrderRouting', 'OrderFilterCondition', 'OrderRoutingRule', 'OrderRoutingRuleInvCond', 'OrderRoutingRuleAction'] as Set, ['OrderRouting', 'OrderFilterCondition', 'OrderRoutingRule', 'OrderRoutingRuleInvCond', 'OrderRoutingRuleAction'] as Set)
+            </script>
         </actions>
     </service>
 </services>

--- a/service/orderrouting.rest.xml
+++ b/service/orderrouting.rest.xml
@@ -70,6 +70,7 @@
         <id name="routingGroupId">
             <method type="get"><entity name="co.hotwax.order.routing.OrderRoutingGroup" operation="one" masterName="default" /></method>
             <method type="post"><entity name="co.hotwax.order.routing.OrderRoutingGroup" operation="store" masterName="default"/></method>
+            <method type="delete"><service name="co.hotwax.order.routing.OrderRoutingServices.delete#OrderRoutingGroup"/></method>
             <resource name="runNow">
                 <method type="post"><service name="co.hotwax.order.routing.OrderRoutingServices.scheduleNow#OrderRoutingGroup"/></method>
             </resource>


### PR DESCRIPTION

If routing was scheduled, it will set serviceJob.thruDate and service.pasused=Y to make scheduled job inactive. To delete order routing group user need DELETE_ORDER_ROUTE permission