### PR TITLE
implement shipment total check in brokering service for order shipgroups

### DIFF
--- a/data/OrderRoutingSeedData.xml
+++ b/data/OrderRoutingSeedData.xml
@@ -60,6 +60,7 @@
     <moqui.basic.Enumeration enumId="IIP_MSMNT_SYSTEM" description="Systems of measurement" sequenceNum="5" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="measurementSystem"/>
     <moqui.basic.Enumeration enumId="IIP_SPLIT_ITEM_GROUP" description="Split order item group" sequenceNum="6" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="splitOrderItemGroup"/>
     <moqui.basic.Enumeration enumId="IFP_IGNORE_ORD_FAC_LIMIT" description="Turn off the Facility order limit check" sequenceNum="7" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="ignoreFacilityOrderLimit"/>
+    <moqui.basic.Enumeration enumId="IFP_SHIP_THREHOLD" description="Shipment threshold check" sequenceNum="8" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="shipmentThreshold"/>
 
     <moqui.basic.EnumerationType enumTypeId="ORD_SORT_PARAM_TYPE" description="Determine the order by parameter considered in a condition" parentTypeId="ORDER_ROUTING"/>
     <moqui.basic.Enumeration enumId="OSP_SHIP_BY" description="Ship by" sequenceNum="5" enumTypeId="ORD_SORT_PARAM_TYPE" enumCode="shipBeforeDate"/><!-- OrderItem.shipBeforeDate -->

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -513,10 +513,13 @@
                         brokeredItemCount = suggestedFulfillmentLocations.size();
                         brokeredItemsSeqIds = suggestedFulfillmentLocations.orderItemSeqId;
                         if (shipmentThreshold > 0) {
+                            def orderAdjustments = ec.entity.find("org.apache.ofbiz.order.order.OrderAdjustment")
+                                    .condition("orderId", orderId)
+                                    .condition("orderItemSeqId", EntityCondition.NOT_EQUAL, "_NA_").list();
                             unfillableItems = orderItems.stream().filter(i -> !brokeredItemsSeqIds.contains(i.orderItemSeqId)).collect(Collectors.toList())
                             if (unfillableItems) {
                                 def result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
-                                    .parameters([orderItems: unfillableItems, orderAdjustments: []]).call()
+                                    .parameters([orderItems: unfillableItems, orderAdjustments: orderAdjustments]).call()
                                 if (shipmentThreshold > result?.subTotal) {
                                     metShipmentThreshold = false;
                                 }
@@ -528,7 +531,7 @@
                                     def items = facilityBrokeredItems.orderItemSeqId
                                     facilityItems = orderItems.stream().filter(i -> items.contains(i.orderItemSeqId)).collect(Collectors.toList())
                                     result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
-                                        .parameters([orderItems: facilityItems, orderAdjustments: []]) .call()
+                                        .parameters([orderItems: facilityItems, orderAdjustments: orderAdjustments]) .call()
                                     if (shipmentThreshold > result?.subTotal) {
                                         metShipmentThreshold = false;
                                     }
@@ -555,10 +558,12 @@
 
                     def unfillableItemSeqIds = orderItems.orderItemSeqId.stream().filter(i -> !brokeredItemsSeqIds.contains(i)).collect(Collectors.toList())
                     if (unfillableItemSeqIds) {
+                        if (!comments) {
                         if (!suggestedFulfillmentLocations) {
                             comments = "${orderRoutingGroup.groupName}: No inventory found for ${routingRule.ruleName}."
                         } else {
                             comments = "${orderRoutingGroup.groupName}: Partially available item inventory found for ${routingRule.ruleName}."
+                        }
                         }
                         // If unfillable items are found, check for actions.
                         if (actionMap.get('ORA_MV_TO_QUEUE') != null) {

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -514,7 +514,7 @@
                         brokeredItemsSeqIds = suggestedFulfillmentLocations.orderItemSeqId;
                         def checkShipmentThreshold = false;
                         def unfillableItems = orderItems.stream().filter(i -> !brokeredItemsSeqIds.contains(i.orderItemSeqId)).collect(Collectors.toList())
-                        if (shipmentThreshold > 0 && !(suggestedFacilityIds.size() == 1 || unfillableItems)) {
+                        if (shipmentThreshold > 0 && !(suggestedFacilityIds.size() == 1 && !unfillableItems)) {
                             checkShipmentThreshold = true
                         }
                         if (checkShipmentThreshold) {
@@ -549,8 +549,8 @@
                         }
                         }
                         if (!metShipmentThreshold) {
-                            comments = "${orderRoutingGroup.groupName} : Shipment threshold not met for ${routingRule.ruleName}."
-                            ec.logger.info("Shipment threshold condition not met for ${routingRule.ruleName} [${routingRule.routingRuleId}] for orderId ${orderId} and shipGroupSeqId ${shipGroupSeqId} and metShipmentThreshold ${metShipmentThreshold}");
+                            comments = "${orderRoutingGroup.groupName} : Shipment threshold not met for rule ${routingRule.ruleName}."
+                            ec.logger.info("Shipment threshold condition not met for rule ${routingRule.ruleName} [${routingRule.routingRuleId}] for orderId ${orderId} and shipGroupSeqId ${shipGroupSeqId} and metShipmentThreshold ${metShipmentThreshold}");
                             facilityAllocation = []
                             brokeredItemsSeqIds = [];
                             brokeredItemCount = 0;

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -330,9 +330,12 @@
                                     .requireNewTransaction(true)
                                     .call()
                             if (!ec.message.hasError()) {
+                                shipmentThresholds = ec.entity.find("co.hotwax.order.routing.OrderRoutingRuleInvCond")
+                                    .condition(["routingRuleId": routingRule.routingRuleId, "fieldName": "shipmentThreshold"]).list()
+                                shipmentThreshold = shipmentThresholds[0]?.fieldValue
                                 actionResult = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.eval#OrderRoutingActions")
                                         .parameters([orderId: nextValue.orderId, shipGroupSeqId: nextValue.shipGroupSeqId,orderItemSeqId: orderItemSeqId, changeReasonEnumId: changeReasonEnumId,
-                                                routingRuleId: routingRule.routingRuleId, suggestedFulfillmentLocations: ruleResult.suggestedFulfillmentLocations, routingRunId: routingRunId])
+                                                routingRuleId: routingRule.routingRuleId, suggestedFulfillmentLocations: ruleResult.suggestedFulfillmentLocations, routingRunId: routingRunId, shipmentThreshold: shipmentThreshold])
                                         .requireNewTransaction(true)
                                         .call()
                                 if (ec.message.hasError()) {
@@ -452,6 +455,7 @@
             <parameter name="orderItemSeqId"/>
             <parameter name="changeReasonEnumId"/>
             <parameter name="routingRunId"/>
+            <parameter name="shipmentThreshold" type="Integer"/>
             <parameter name="routingRuleId" required="true"/>
             <parameter name="suggestedFulfillmentLocations" type="List"/>
         </in-parameters>
@@ -504,10 +508,35 @@
                         }
                     }
                     //prepare map for brokered items
-                    def queue = null, autoCancelDate = null, brokeredItemsSeqIds = [] ;
+                    def queue = null, autoCancelDate = null, brokeredItemsSeqIds = [], metShipmentThreshold = true;
                     if (suggestedFulfillmentLocations) {
                         brokeredItemCount = suggestedFulfillmentLocations.size();
                         brokeredItemsSeqIds = suggestedFulfillmentLocations.orderItemSeqId;
+                        if (shipmentThreshold > 0) {
+                            unfillableItems = orderItems.stream().filter(i -> !brokeredItemsSeqIds.contains(i.orderItemSeqId)).collect(Collectors.toList())
+                            if (unfillableItems) {
+                                def result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
+                                    .parameters([orderItems: unfillableItems, orderAdjustments: []]).call()
+                                if (shipmentThreshold > result?.subTotal) {
+                                    metShipmentThreshold = false;
+                                }
+                            }
+                            if (metShipmentThreshold) {
+                                suggestedFacilityIds.each { facilityId->
+                                    def facilityBrokeredItems = suggestedFulfillmentLocations.collect()
+                                    filterMapList(facilityBrokeredItems, ["facilityId":facilityId], false)
+                                    def items = facilityBrokeredItems.orderItemSeqId
+                                    facilityItems = orderItems.stream().filter(i -> items.contains(i.orderItemSeqId)).collect(Collectors.toList())
+                                    result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
+                                        .parameters([orderItems: facilityItems, orderAdjustments: []]) .call()
+                                    if (shipmentThreshold > result?.subTotal) {
+                                        metShipmentThreshold = false;
+                                    }
+                                }
+                            }
+                        }
+                        if (metShipmentThreshold) {
+                            brokeredItemCount = suggestedFulfillmentLocations.size();
                         suggestedFacilityIds.each { facilityId->
                             def facilityItems = suggestedFulfillmentLocations.collect()
                             filterMapList(facilityItems, ["facilityId":facilityId], false)
@@ -516,7 +545,14 @@
                                     routingGroupId: orderRoutingGroup.routingGroupId, orderRoutingId:orderRouting.orderRoutingId, routingRuleId:routingRule.routingRuleId,
                                     routingRunId: routingRunId])
                         }
+                        } else {
+                            comments = "${orderRoutingGroup.groupName} : Shipment threshold not met for ${routingRule.ruleName}."
+                            ec.logger.info("Shipment threshold condition not met for ${routingRule.ruleName} [${routingRule.routingRuleId}] for orderId ${orderId} and shipGroupSeqId ${shipGroupSeqId} and metShipmentThreshold ${metShipmentThreshold}");
+                            suggestedFulfillmentLocations = []
+                            brokeredItemsSeqIds = [];
+                        }
                     }
+
                     def unfillableItemSeqIds = orderItems.orderItemSeqId.stream().filter(i -> !brokeredItemsSeqIds.contains(i)).collect(Collectors.toList())
                     if (unfillableItemSeqIds) {
                         if (!suggestedFulfillmentLocations) {
@@ -899,5 +935,28 @@
                 }
             ]]></script>
         </actions>
+    </service>
+    <service verb="calculate" noun="ItemSubtotal">
+        <in-parameters>
+            <parameter name="orderItems" type="List" required="true"/>
+            <parameter name="orderAdjustments" type="List"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="subTotal"/>
+        </out-parameters>
+        <actions>
+            <set field="subTotal" value="0" type="BigDecimal"/>
+            <iterate list="orderItems" entry="orderItem">
+                <set field="itemAmount" from="orderItem.quantity * orderItem.unitPrice" type="BigDecimal"/>
+                <filter-map-list list="orderAdjustments" to-list="itemAdjustments">
+                    <field-map field-name="orderItemSeqId" from="orderItem.orderItemSeqId"/>
+                </filter-map-list>
+                <script>
+                    def adjAmount = orderAdjustments?orderAdjustments.collect { adj -> adj.amount ?: 0 }.sum(): 0.0;
+                </script>
+                <set field="subTotal" from="subTotal+ itemAmount + adjAmount"/>
+            </iterate>
+        </actions>
+
     </service>
 </services>

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -512,29 +512,20 @@
                     if (suggestedFulfillmentLocations) {
                         brokeredItemCount = suggestedFulfillmentLocations.size();
                         brokeredItemsSeqIds = suggestedFulfillmentLocations.orderItemSeqId;
-                        if (shipmentThreshold > 0) {
+                        def checkShipmentThreshold = false;
+                        def unfillableItems = orderItems.stream().filter(i -> !brokeredItemsSeqIds.contains(i.orderItemSeqId)).collect(Collectors.toList())
+                        if (shipmentThreshold > 0 && !(suggestedFacilityIds.size() == 1 || unfillableItems)) {
+                            checkShipmentThreshold = true
+                        }
+                        if (checkShipmentThreshold) {
                             def orderAdjustments = ec.entity.find("org.apache.ofbiz.order.order.OrderAdjustment")
                                     .condition("orderId", orderId)
                                     .condition("orderItemSeqId", EntityCondition.NOT_EQUAL, "_NA_").list();
-                            unfillableItems = orderItems.stream().filter(i -> !brokeredItemsSeqIds.contains(i.orderItemSeqId)).collect(Collectors.toList())
                             if (unfillableItems) {
                                 def result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
                                     .parameters([orderItems: unfillableItems, orderAdjustments: orderAdjustments]).call()
                                 if (shipmentThreshold > result?.subTotal) {
                                     metShipmentThreshold = false;
-                                }
-                            }
-                            if (metShipmentThreshold) {
-                                suggestedFacilityIds.each { facilityId->
-                                    def facilityBrokeredItems = suggestedFulfillmentLocations.collect()
-                                    filterMapList(facilityBrokeredItems, ["facilityId":facilityId], false)
-                                    def items = facilityBrokeredItems.orderItemSeqId
-                                    facilityItems = orderItems.stream().filter(i -> items.contains(i.orderItemSeqId)).collect(Collectors.toList())
-                                    result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
-                                        .parameters([orderItems: facilityItems, orderAdjustments: orderAdjustments]) .call()
-                                    if (shipmentThreshold > result?.subTotal) {
-                                        metShipmentThreshold = false;
-                                    }
                                 }
                             }
                         }
@@ -544,15 +535,25 @@
                             def facilityItems = suggestedFulfillmentLocations.collect()
                             filterMapList(facilityItems, ["facilityId":facilityId], false)
                             def items = facilityItems.collect { [orderItemSeqId: it.orderItemSeqId] }
+                            if (checkShipmentThreshold) {
+                                def brokeredItems = orderItems.stream().filter(i -> (items.orderItemSeqId).contains(i.orderItemSeqId)).collect(Collectors.toList())
+                                result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
+                                    .parameters([orderItems: brokeredItems, orderAdjustments: orderAdjustments]) .call()
+                                if (shipmentThreshold > result?.subTotal) {
+                                    metShipmentThreshold = false;
+                                }
+                            }
                             facilityAllocation.add([facilityId:facilityId, items: items, comments: comments, routingRule: routingRuleName, changeReasonEnumId: changeReasonEnumId?:"BROKERED",
                                     routingGroupId: orderRoutingGroup.routingGroupId, orderRoutingId:orderRouting.orderRoutingId, routingRuleId:routingRule.routingRuleId,
                                     routingRunId: routingRunId])
                         }
-                        } else {
+                        }
+                        if (!metShipmentThreshold) {
                             comments = "${orderRoutingGroup.groupName} : Shipment threshold not met for ${routingRule.ruleName}."
                             ec.logger.info("Shipment threshold condition not met for ${routingRule.ruleName} [${routingRule.routingRuleId}] for orderId ${orderId} and shipGroupSeqId ${shipGroupSeqId} and metShipmentThreshold ${metShipmentThreshold}");
-                            suggestedFulfillmentLocations = []
+                            facilityAllocation = []
                             brokeredItemsSeqIds = [];
+                            brokeredItemCount = 0;
                         }
                     }
 

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -455,7 +455,7 @@
             <parameter name="orderItemSeqId"/>
             <parameter name="changeReasonEnumId"/>
             <parameter name="routingRunId"/>
-            <parameter name="shipmentThreshold" type="Integer"/>
+            <parameter name="shipmentThreshold" type="BigDecimal"/>
             <parameter name="routingRuleId" required="true"/>
             <parameter name="suggestedFulfillmentLocations" type="List"/>
         </in-parameters>


### PR DESCRIPTION
Added Brokering Shipment Threshold Support

- User can now configure a brokering shipment threshold at the routing rule level.
- If the inventory allocation returns a single location for the ship group items, the shipment threshold check will be skipped.
- If the inventory allocation returns multiple locations for the same ship group items, brokering will perform the threshold check.
- If all the location items meet the threshold check, the ship group items will proceed with brokering.
- If any of the location items fail the threshold check, the routing rule action will be triggerd if set, else next rule will be executed
- In case of split allow, if there are some unfillable items exists , the system will perform the threshold check on the unfillable items as well, so all the location items along with unfillalbe items should meet the threshold criteria.