### PR TITLE
53 broker only if all items are available

### DIFF
--- a/data/OrderRoutingSeedData.xml
+++ b/data/OrderRoutingSeedData.xml
@@ -61,6 +61,7 @@
     <moqui.basic.Enumeration enumId="IIP_SPLIT_ITEM_GROUP" description="Split order item group" sequenceNum="6" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="splitOrderItemGroup"/>
     <moqui.basic.Enumeration enumId="IFP_IGNORE_ORD_FAC_LIMIT" description="Turn off the Facility order limit check" sequenceNum="7" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="ignoreFacilityOrderLimit"/>
     <moqui.basic.Enumeration enumId="IFP_SHIP_THREHOLD" description="Shipment threshold check" sequenceNum="8" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="shipmentThreshold"/>
+    <moqui.basic.Enumeration enumId="IFP_ALL_ITEM_AVAIL_COND" description="Broker only if all ship group items are available (either at a single location or across multiple locations)" sequenceNum="9" enumTypeId="INV_FILTER_PRM_TYPE" enumCode="brokerIfAllItemsAvailable"/>
 
     <moqui.basic.EnumerationType enumTypeId="ORD_SORT_PARAM_TYPE" description="Determine the order by parameter considered in a condition" parentTypeId="ORDER_ROUTING"/>
     <moqui.basic.Enumeration enumId="OSP_SHIP_BY" description="Ship by" sequenceNum="5" enumTypeId="ORD_SORT_PARAM_TYPE" enumCode="shipBeforeDate"/><!-- OrderItem.shipBeforeDate -->

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -450,7 +450,7 @@
                 try {
                 Writer writer = new StringWriter()
                 ec.resourceFacade.template(templateLoc, writer)
-                //ec.logger.info("======writer==${writer}==")
+                //ec.logger.info("======writer==${writer}==")ec.logger.info("======writer==${writer}==")
                 ec.getEntity().getConnection(productStore.getEntityGroupName()).withCloseable ({ java.sql.Connection con ->
                 con.createStatement().withCloseable({ statement ->
                     statement.executeQuery(writer.toString()).withCloseable({resultSet ->
@@ -528,8 +528,6 @@
                 <field-map field-name="fieldName" value="brokerIfAllItemsAvailable"/>
             </filter-map-list>
             <set field="brokerIfAllItemsAvailable" from="brokerIfAllItemsAvailableCond[0]?.getBoolean('fieldValue')" default-value="false" type="Boolean"/>
-            <log message="===brokerIfAllItemsAvailable==${brokerIfAllItemsAvailable}=="/>
-            <log message="===shipmentThreshold==${shipmentThreshold}=="/>
             <script><![CDATA[
                     import java.time.format.DateTimeFormatter;
                     import java.time.ZonedDateTime

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -450,7 +450,7 @@
                 try {
                 Writer writer = new StringWriter()
                 ec.resourceFacade.template(templateLoc, writer)
-                //ec.logger.info("======writer==${writer}==")ec.logger.info("======writer==${writer}==")
+                //ec.logger.info("======writer==${writer}==")
                 ec.getEntity().getConnection(productStore.getEntityGroupName()).withCloseable ({ java.sql.Connection con ->
                 con.createStatement().withCloseable({ statement ->
                     statement.executeQuery(writer.toString()).withCloseable({resultSet ->

--- a/service/co/hotwax/order/routing/OrderRoutingServices.xml
+++ b/service/co/hotwax/order/routing/OrderRoutingServices.xml
@@ -189,7 +189,7 @@
                     } else {
                         routingResult = ec.message.getMessagesString()
                     }
-                    if (routingResult && routingResult.length() &gt; 255) {
+                    if (routingResult && routingResult.length() > 255) {
                         routingResult = routingResult.substring(0, 255)
                     }
                     ec.message.clearAll();
@@ -349,12 +349,9 @@
                                     .call()
 
                             if (!ec.message.hasError()) {
-                                shipmentThresholds = ec.entity.find("co.hotwax.order.routing.OrderRoutingRuleInvCond")
-                                    .condition(["routingRuleId": routingRule.routingRuleId, "fieldName": "shipmentThreshold"]).list()
-                                shipmentThreshold = shipmentThresholds[0]?.fieldValue
                                 actionResult = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.eval#OrderRoutingActions")
                                         .parameters([orderId: nextValue.orderId, shipGroupSeqId: nextValue.shipGroupSeqId,orderItemSeqId: orderItemSeqId, changeReasonEnumId: changeReasonEnumId,
-                                                routingRuleId: routingRule.routingRuleId, suggestedFulfillmentLocations: ruleResult.suggestedFulfillmentLocations, routingRunId: routingRunId, shipmentThreshold: shipmentThreshold])
+                                                routingRuleId: routingRule.routingRuleId, suggestedFulfillmentLocations: ruleResult.suggestedFulfillmentLocations, routingRunId: routingRunId])
                                         .requireNewTransaction(true)
                                         .call()
                                 if (ec.message.hasError()) {
@@ -491,7 +488,6 @@
             <parameter name="orderItemSeqId"/>
             <parameter name="changeReasonEnumId"/>
             <parameter name="routingRunId"/>
-            <parameter name="shipmentThreshold" type="BigDecimal"/>
             <parameter name="routingRuleId" required="true"/>
             <parameter name="suggestedFulfillmentLocations" type="List"/>
         </in-parameters>
@@ -520,7 +516,21 @@
                     <econdition field-name="actionValue"  operator="is-not-null"/>
                 </econditions>
             </entity-find>
-                <script><![CDATA[
+            <entity-find entity-name="co.hotwax.order.routing.OrderRoutingRuleInvCond" list="extraConditions" cache="true">
+                <econdition field-name="routingRuleId" from="routingRuleId"/>
+                <order-by field-name="sequenceNum"/>
+            </entity-find>
+            <filter-map-list list="extraConditions" to-list="shipmentThresholds">
+                <field-map field-name="fieldName" value="shipmentThreshold"/>
+            </filter-map-list>
+            <set field="shipmentThreshold" from="shipmentThresholds[0].fieldValue" type="BigDecimal"/>
+            <filter-map-list list="extraConditions" to-list="brokerIfAllItemsAvailableCond">
+                <field-map field-name="fieldName" value="brokerIfAllItemsAvailable"/>
+            </filter-map-list>
+            <set field="brokerIfAllItemsAvailable" from="brokerIfAllItemsAvailableCond[0]?.getBoolean('fieldValue')" default-value="false" type="Boolean"/>
+            <log message="===brokerIfAllItemsAvailable==${brokerIfAllItemsAvailable}=="/>
+            <log message="===shipmentThreshold==${shipmentThreshold}=="/>
+            <script><![CDATA[
                     import java.time.format.DateTimeFormatter;
                     import java.time.ZonedDateTime
                     import java.util.stream.Collectors;
@@ -544,13 +554,19 @@
                         }
                     }
                     //prepare map for brokered items
-                    def queue = null, autoCancelDate = null, brokeredItemsSeqIds = [], metShipmentThreshold = true, orderAdjustments = null ;
+                    def queue = null, autoCancelDate = null, brokeredItemsSeqIds = [], allocateFacilityToItems = true, orderAdjustments = null ;
                     if (suggestedFulfillmentLocations) {
                         brokeredItemCount = suggestedFulfillmentLocations.size();
                         brokeredItemsSeqIds = suggestedFulfillmentLocations.orderItemSeqId;
                         def checkShipmentThreshold = false;
                         def unfillableItems = orderItems.stream().filter(i -> !brokeredItemsSeqIds.contains(i.orderItemSeqId)).collect(Collectors.toList())
-                        if (shipmentThreshold > 0 && !(suggestedFacilityIds.size() == 1 && !unfillableItems)) {
+
+                        if (brokerIfAllItemsAvailable && unfillableItems) {
+                            allocateFacilityToItems = false;
+                            comments = "${orderRoutingGroup.groupName} : Inventory is not available for all items for rule ${routingRule.ruleName}."
+                            ec.logger.info("Inventory is not available for all items condition not met for rule ${routingRule.ruleName} [${routingRule.routingRuleId}] for orderId ${orderId} and shipGroupSeqId ${shipGroupSeqId}");
+                        }
+                        if (allocateFacilityToItems && shipmentThreshold > 0 && !(suggestedFacilityIds.size() == 1 && !unfillableItems)) {
                             checkShipmentThreshold = true
                         }
                         if (checkShipmentThreshold) {
@@ -561,11 +577,11 @@
                                 def result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
                                     .parameters([orderItems: unfillableItems, orderAdjustments: orderAdjustments]).call()
                                 if (shipmentThreshold > result?.subTotal) {
-                                    metShipmentThreshold = false;
+                                    allocateFacilityToItems = false;
                                 }
                             }
                         }
-                        if (metShipmentThreshold) {
+                        if (allocateFacilityToItems) {
                             brokeredItemCount = suggestedFulfillmentLocations.size();
                         suggestedFacilityIds.each { facilityId->
                             def facilityItems = suggestedFulfillmentLocations.collect()
@@ -576,17 +592,19 @@
                                 result = ec.service.sync().name("co.hotwax.order.routing.OrderRoutingServices.calculate#ItemSubtotal")
                                     .parameters([orderItems: brokeredItems, orderAdjustments: orderAdjustments]) .call()
                                 if (shipmentThreshold > result?.subTotal) {
-                                    metShipmentThreshold = false;
+                                    allocateFacilityToItems = false;
                                 }
                             }
                             facilityAllocation.add([facilityId:facilityId, items: items, comments: comments, routingRule: routingRuleName, changeReasonEnumId: changeReasonEnumId?:"BROKERED",
                                     routingGroupId: orderRoutingGroup.routingGroupId, orderRoutingId:orderRouting.orderRoutingId, routingRuleId:routingRule.routingRuleId,
                                     routingRunId: routingRunId])
                         }
-                        }
-                        if (!metShipmentThreshold) {
+                        if (allocateFacilityToItems) {
                             comments = "${orderRoutingGroup.groupName} : Shipment threshold not met for rule ${routingRule.ruleName}."
                             ec.logger.info("Shipment threshold condition not met for rule ${routingRule.ruleName} [${routingRule.routingRuleId}] for orderId ${orderId} and shipGroupSeqId ${shipGroupSeqId} and metShipmentThreshold ${metShipmentThreshold}");
+                        }
+                        }
+                        if (!allocateFacilityToItems) {
                             facilityAllocation = []
                             brokeredItemsSeqIds = [];
                             brokeredItemCount = 0;

--- a/sql/InventorySourceSelector.sql.ftl
+++ b/sql/InventorySourceSelector.sql.ftl
@@ -13,7 +13,8 @@
   <#assign ignoreFacilityOrderLimit = true />
 </#if>
 <#assign splitGroupItem = true />
-<#if (splitOrderItemGroup?has_content && "N" == splitOrderItemGroup.fieldValue!) && "ORA_MULTI" == orderRoutingRule.assignmentEnumId!>
+<#if splitOrderItemGroup?has_content && splitOrderItemGroup.fieldValue?has_content
+  && ("N"?lower_case == splitOrderItemGroup.fieldValue?lower_case || "flase"?lower_case == splitOrderItemGroup.fieldValue?lower_case) && "ORA_MULTI" == orderRoutingRule.assignmentEnumId!>
   <#assign splitGroupItem = false />
 </#if>
 


### PR DESCRIPTION
- Added support to configure a routing rule for brokering order ship group items only if all items are available (either at a single location or across multiple locations).
- Introduced a new Enumeration for inventory condition.
- Updated the eval#OrderRoutingActions service to include this new condition.
- The default value for the condition is set to false. The brokering engine will honor this condition only if explicitly configured in the rules.
- If the "broker only if all items are available" condition is true, the brokering engine checks for any unfillable items. If found, no facility location will be allocated to the order items, and the routing action will proceed according to the configuration.
- Accepted values are
  - **true/false/TRUE/FALSE/Y/N/y/n**
- Shipment threshold is now retrieved within eval#OrderRoutingActions, removing the need to pass it as a parameter.